### PR TITLE
Upgrade cxf-core to version 3.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-core</artifactId>
-            <version>3.1.2</version>
+            <version>3.5.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades cxf-core to 3.5.5 to fix vulnerabilities in current version